### PR TITLE
Pass the action class name directly to the ActionJob

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -20,7 +20,7 @@ class ActionJob implements ShouldQueue
 
     public function __construct($action, array $parameters)
     {
-        $this->actionClass = get_class($action);
+        $this->actionClass = is_string($action) ? $action : get_class($action);
         $this->parameters = $parameters;
 
         $this->resolveQueueableProperties($action);

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -18,7 +18,7 @@ class ActionJob implements ShouldQueue
     /** @var array */
     protected $parameters;
 
-    public function __construct($action, array $parameters)
+    public function __construct($action, array $parameters = [])
     {
         $this->actionClass = is_string($action) ? $action : get_class($action);
         $this->parameters = $parameters;

--- a/tests/ActionJobTest.php
+++ b/tests/ActionJobTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests;
+
+use Spatie\QueueableAction\ActionJob;
+use Spatie\QueueableAction\Tests\TestClasses\DataObject;
+use Spatie\QueueableAction\Tests\TestClasses\SimpleAction;
+use Spatie\QueueableAction\Tests\TestClasses\ComplexAction;
+
+class ActionJobTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_instantiated_from_the_action_class()
+    {
+        $actionJob = new ActionJob(SimpleAction::class);
+
+        $this->assertInstanceOf(ActionJob::class, $actionJob);
+        $this->assertEquals(SimpleAction::class, $actionJob->displayName());
+    }
+
+    /** @test */
+    public function it_can_be_instantiated_from_an_action_instance()
+    {
+        $complexAction = app(ComplexAction::class);
+
+        $actionJob = new ActionJob($complexAction, [new DataObject('foo')]);
+
+        $this->assertInstanceOf(ActionJob::class, $actionJob);
+        $this->assertEquals(ComplexAction::class, $actionJob->displayName());
+    }
+}

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -89,11 +89,11 @@ class QueueableActionTest extends TestCase
         $action->onQueue()
             ->execute(new DataObject('foo'))
             ->chain([
-                new ActionJob(SimpleAction::class, []),
+                new ActionJob(SimpleAction::class),
             ]);
 
         Queue::assertPushedWithChain(ActionJob::class, [
-            new ActionJob(SimpleAction::class, []),
+            new ActionJob(SimpleAction::class),
         ]);
     }
 }

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -77,4 +77,23 @@ class QueueableActionTest extends TestCase
 
         $this->assertLogHas('foo bar');
     }
+
+    /** @test */
+    public function an_action_can_be_queued_with_a_chain_of_other_actions_jobs()
+    {
+        Queue::fake();
+
+        /** @var \Spatie\QueueableAction\Tests\TestClasses\ComplexAction $action */
+        $action = app(ComplexAction::class);
+
+        $action->onQueue()
+            ->execute(new DataObject('foo'))
+            ->chain([
+                new ActionJob(SimpleAction::class, []),
+            ]);
+
+        Queue::assertPushedWithChain(ActionJob::class, [
+            new ActionJob(SimpleAction::class, []),
+        ]);
+    }
 }


### PR DESCRIPTION
I came a cross a situation, where I needed to dynamically chain other instances of `ActionJob` to the one being queued.

That can be accomplished like this:

```php
$this->actionOne->onQueue()
    ->execute($arg)
    ->chain([
        new ActionJob(app(ActionTwo::class), [$argOne, $argTwo]),
        new ActionJob(app(ActionThree::class), [$argOne, $argTwo]),
    ]);
```

After this PR it is no longer required to resolve the chained actions.

```php
$this->actionOne->onQueue()
    ->execute($arg)
    ->chain([
        new ActionJob(ActionTwo::class, [$argOne, $argTwo]),
        new ActionJob(ActionThree::class, [$argOne, $argTwo]),
    ]);
```