### PR TITLE
Add 'tries' and 'timeout' as queueable properties.

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -52,6 +52,8 @@ class ActionJob implements ShouldQueue
             'chainQueue',
             'delay',
             'chained',
+            'tries',
+            'timeout',
         ];
 
         foreach ($queueableProperties as $queueableProperty) {

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -57,8 +57,8 @@ class ActionJob implements ShouldQueue
         ];
 
         foreach ($queueableProperties as $queueableProperty) {
-            if(property_exists($action, $queueableProperty) {
-                $this->{$queueableProperty} = $action->{$queueableProperty};   
+            if(property_exists($action, $queueableProperty)) {
+                $this->{$queueableProperty} = $action->{$queueableProperty};
             }
         }
     }

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -57,7 +57,9 @@ class ActionJob implements ShouldQueue
         ];
 
         foreach ($queueableProperties as $queueableProperty) {
-            $this->{$queueableProperty} = $action->{$queueableProperty} ?? $this->{$queueableProperty};
+            if(property_exists($action, $queueableProperty) {
+                $this->{$queueableProperty} = $action->{$queueableProperty};   
+            }
         }
     }
 }


### PR DESCRIPTION
As described in [this section of the Laravel documentation](https://laravel.com/docs/5.8/queues#max-job-attempts-and-timeout), you can override the "tries" and "timeout" properties of the queue inside your Laravel Job. This PR adds this ability to the ActionJob.

