### PR TITLE
Implement make:action artisan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ you should read the dedicated blog post: [https://stitcher.io/blog/laravel-queue
 You can use the following Artisan command to generate queueable and synchronous action classes on the fly.
 
 ```
-php artisan make:action MyAction [-sync]
+php artisan make:action MyAction [--sync]
 ```
 
 Here's an example of queueable actions in use:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ composer require spatie/laravel-queueable-action
 If you want to know about the reasoning behind actions and their asynchronous usage, 
 you should read the dedicated blog post: [https://stitcher.io/blog/laravel-queueable-actions](https://stitcher.io/blog/laravel-queueable-actions).
 
+You can use the following Artisan command to generate queueable and synchronous action classes on the fly.
+
+```
+php artisan make:action MyAction [-sync]
+```
+
 Here's an example of queueable actions in use:
 
 ``` php

--- a/composer.json
+++ b/composer.json
@@ -57,5 +57,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\QueueableAction\\QueueableActionServiceProvider"
+            ]
+        }
     }
 }

--- a/src/ActionMakeCommand.php
+++ b/src/ActionMakeCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\QueueableAction;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ActionMakeCommand extends GeneratorCommand
+{
+    protected $name = 'make:action';
+
+    protected $description = 'Create a new action class';
+
+    protected $type = 'Action';
+
+    protected function getStub(): string
+    {
+        return $this->option('sync')
+            ? __DIR__ . '/stubs/action.stub'
+            : __DIR__ . '/stubs/action-queued.stub';
+    }
+
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace . '\Actions';
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['sync', null, InputOption::VALUE_NONE, 'Indicates that action should be synchronous'],
+        ];
+    }
+}

--- a/src/ActionMakeCommand.php
+++ b/src/ActionMakeCommand.php
@@ -22,7 +22,7 @@ class ActionMakeCommand extends GeneratorCommand
 
     protected function getDefaultNamespace($rootNamespace): string
     {
-        return $rootNamespace . '\Actions';
+        return $rootNamespace.'\Actions';
     }
 
     protected function getOptions(): array

--- a/src/ActionMakeCommand.php
+++ b/src/ActionMakeCommand.php
@@ -16,8 +16,8 @@ class ActionMakeCommand extends GeneratorCommand
     protected function getStub(): string
     {
         return $this->option('sync')
-            ? __DIR__ . '/stubs/action.stub'
-            : __DIR__ . '/stubs/action-queued.stub';
+            ? __DIR__.'/stubs/action.stub'
+            : __DIR__.'/stubs/action-queued.stub';
     }
 
     protected function getDefaultNamespace($rootNamespace): string

--- a/src/QueueableActionServiceProvider.php
+++ b/src/QueueableActionServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\QueueableAction;
+
+use Illuminate\Support\ServiceProvider;
+
+class QueueableActionServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ActionMakeCommand::class,
+            ]);
+        }
+    }
+
+    public function provides(): array
+    {
+        return [
+            ActionMakeCommand::class,
+        ];
+    }
+}

--- a/src/stubs/action-queued.stub
+++ b/src/stubs/action-queued.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace DummyNamespace;
+
+use Spatie\QueueableAction\QueueableAction;
+
+class DummyClass
+{
+    use QueueableAction;
+
+    /**
+     * Create a new action instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        // Prepare the action for execution, leveraging constructor injection.
+    }
+
+    /**
+     * Execute the action.
+     *
+     * @return mixed
+     */
+    public function execute()
+    {
+        // The business logic goes here.
+    }
+}

--- a/src/stubs/action.stub
+++ b/src/stubs/action.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace DummyNamespace;
+
+class DummyClass
+{
+    /**
+     * Create a new action instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        // Prepare the action for execution, leveraging constructor injection.
+    }
+
+    /**
+     * Execute the action.
+     *
+     * @return mixed
+     */
+    public function execute()
+    {
+        // The business logic goes here.
+    }
+}

--- a/tests/ActionMakeCommandTest.php
+++ b/tests/ActionMakeCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests;
+
+use Illuminate\Filesystem\Filesystem;
+use Mockery\MockInterface;
+
+class ActionMakeCommandTest extends TestCase
+{
+    /** @test */
+    public function it_generates_queueable_actions(): void
+    {
+        $this->expectsGeneratedClass('TestAction', file_get_contents(__DIR__ . '/stubs/test-action-queued.stub'));
+
+        $this->artisan('make:action', [
+            'name' => 'TestAction'
+        ])->expectsOutput('Action created successfully.')->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_generates_synchronous_actions(): void
+    {
+        $this->expectsGeneratedClass('TestAction', file_get_contents(__DIR__ . '/stubs/test-action.stub'));
+
+        $this->artisan('make:action', [
+            'name' => 'TestAction',
+            '--sync' => true
+        ])->expectsOutput('Action created successfully.')->assertExitCode(0);
+    }
+
+    private function expectsGeneratedClass(string $filename, string $contents): void
+    {
+        $this->mock(Filesystem::class, static function (MockInterface $mock) use ($filename, $contents) {
+            $mock->makePartial()
+                ->expects('put')
+                ->withArgs(static function ($path, $compiled) use ($filename, $contents) {
+                    return $path === app_path("Actions/{$filename}.php")
+                        && $compiled === $contents;
+                })
+                ->andReturn(true);
+        });
+    }
+}

--- a/tests/ActionMakeCommandTest.php
+++ b/tests/ActionMakeCommandTest.php
@@ -2,29 +2,29 @@
 
 namespace Spatie\QueueableAction\Tests;
 
-use Illuminate\Filesystem\Filesystem;
 use Mockery\MockInterface;
+use Illuminate\Filesystem\Filesystem;
 
 class ActionMakeCommandTest extends TestCase
 {
     /** @test */
     public function it_generates_queueable_actions(): void
     {
-        $this->expectsGeneratedClass(app_path('Actions/TestAction.php'), file_get_contents(__DIR__ . '/stubs/test-action-queued.stub'));
+        $this->expectsGeneratedClass(app_path('Actions/TestAction.php'), file_get_contents(__DIR__.'/stubs/test-action-queued.stub'));
 
         $this->artisan('make:action', [
-            'name' => 'TestAction'
+            'name' => 'TestAction',
         ])->expectsOutput('Action created successfully.')->assertExitCode(0);
     }
 
     /** @test */
     public function it_generates_synchronous_actions(): void
     {
-        $this->expectsGeneratedClass(app_path('Actions/TestAction.php'), file_get_contents(__DIR__ . '/stubs/test-action.stub'));
+        $this->expectsGeneratedClass(app_path('Actions/TestAction.php'), file_get_contents(__DIR__.'/stubs/test-action.stub'));
 
         $this->artisan('make:action', [
             'name' => 'TestAction',
-            '--sync' => true
+            '--sync' => true,
         ])->expectsOutput('Action created successfully.')->assertExitCode(0);
     }
 

--- a/tests/ActionMakeCommandTest.php
+++ b/tests/ActionMakeCommandTest.php
@@ -10,7 +10,7 @@ class ActionMakeCommandTest extends TestCase
     /** @test */
     public function it_generates_queueable_actions(): void
     {
-        $this->expectsGeneratedClass('TestAction', file_get_contents(__DIR__ . '/stubs/test-action-queued.stub'));
+        $this->expectsGeneratedClass(app_path('Actions/TestAction.php'), file_get_contents(__DIR__ . '/stubs/test-action-queued.stub'));
 
         $this->artisan('make:action', [
             'name' => 'TestAction'
@@ -20,7 +20,7 @@ class ActionMakeCommandTest extends TestCase
     /** @test */
     public function it_generates_synchronous_actions(): void
     {
-        $this->expectsGeneratedClass('TestAction', file_get_contents(__DIR__ . '/stubs/test-action.stub'));
+        $this->expectsGeneratedClass(app_path('Actions/TestAction.php'), file_get_contents(__DIR__ . '/stubs/test-action.stub'));
 
         $this->artisan('make:action', [
             'name' => 'TestAction',
@@ -34,7 +34,7 @@ class ActionMakeCommandTest extends TestCase
             $mock->makePartial()
                 ->expects('put')
                 ->withArgs(static function ($path, $compiled) use ($filename, $contents) {
-                    return $path === app_path("Actions/{$filename}.php")
+                    return $path === $filename
                         && $compiled === $contents;
                 })
                 ->andReturn(true);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spatie\QueueableAction\Tests;
 
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Spatie\QueueableAction\QueueableActionServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
@@ -13,6 +14,13 @@ class TestCase extends OrchestraTestCase
         parent::setUp();
 
         $this->clearLog();
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            QueueableActionServiceProvider::class
+        ];
     }
 
     protected function clearLog()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ class TestCase extends OrchestraTestCase
     protected function getPackageProviders($app): array
     {
         return [
-            QueueableActionServiceProvider::class
+            QueueableActionServiceProvider::class,
         ];
     }
 

--- a/tests/stubs/test-action-queued.stub
+++ b/tests/stubs/test-action-queued.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions;
+
+use Spatie\QueueableAction\QueueableAction;
+
+class TestAction
+{
+    use QueueableAction;
+
+    /**
+     * Create a new action instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        // Prepare the action for execution, leveraging constructor injection.
+    }
+
+    /**
+     * Execute the action.
+     *
+     * @return mixed
+     */
+    public function execute()
+    {
+        // The business logic goes here.
+    }
+}

--- a/tests/stubs/test-action.stub
+++ b/tests/stubs/test-action.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions;
+
+class TestAction
+{
+    /**
+     * Create a new action instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        // Prepare the action for execution, leveraging constructor injection.
+    }
+
+    /**
+     * Execute the action.
+     *
+     * @return mixed
+     */
+    public function execute()
+    {
+        // The business logic goes here.
+    }
+}


### PR DESCRIPTION
For myself, and hopefully many others, this will be the missing link to making the jump from leveraging Jobs in a similar fashion now to Actions without any hindrance of workflows.

I erred on the side of conformity, following the command signature for generating jobs in Laravel which is asynchronous by default, synchronous with the `--sync` trigger. If it would be open for discussion, given the nature of Actions, it might make more sense to flip that and make generating actions synchronous by default and queueable with a `--queue` switch, or similar.

It took a minute to realize a test scenario which was both practical and yielded worthwhile results, but if there is a better way I would be very interested to know what that might be.