### PR TITLE
Allow Laravel 7

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,13 @@ jobs:
             fail-fast: true
             matrix:
                 php: [7.2, 7.3, 7.4]
-                laravel: [6.*]
+                laravel: [6.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     - laravel: 6.*
                       testbench: 4.*
+                    - laravel: 7.*
+                      testbench: 5.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel/framework": "^6.0"
+        "laravel/framework": "^6.0|^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "^4.0|^5.0",
         "phpunit/phpunit": "^8.4",
         "mockery/mockery": "^1.2"
     },


### PR DESCRIPTION
- Change github action workflow file to test both Laravel 6 & 7
- Allow Laravel `^6.0|^7.0` in composer