### PR TITLE
failed() method support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.result.cache

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -8,6 +8,7 @@ use Spatie\QueueableAction\ActionJob;
 use Spatie\QueueableAction\Tests\TestClasses\ActionWithFailedMethod;
 use Spatie\QueueableAction\Tests\TestClasses\ComplexAction;
 use Spatie\QueueableAction\Tests\TestClasses\DataObject;
+use Spatie\QueueableAction\Tests\TestClasses\FailingAction;
 use Spatie\QueueableAction\Tests\TestClasses\SimpleAction;
 use Spatie\QueueableAction\Tests\TestClasses\TaggedAction;
 
@@ -140,5 +141,21 @@ class QueueableActionTest extends TestCase
         Queue::assertPushed(ActionJob::class, function ($action) {
             return $action->failed(new Exception('foo')) === 'foo';
         });
+    }
+
+    /** @test */
+    public function the_failed_callback_is_executed_on_failure()
+    {
+        $action = new FailingAction();
+
+        try {
+            $action->onQueue()->execute();
+        } catch (Exception $e) {
+            //
+        }
+
+        $this->assertSame('foobar', $_SERVER['_test_failed_message']);
+        
+        unset($_SERVER['_test_failed_message']); // cleanup
     }
 }

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -2,8 +2,10 @@
 
 namespace Spatie\QueueableAction\Tests;
 
+use Exception;
 use Illuminate\Support\Facades\Queue;
 use Spatie\QueueableAction\ActionJob;
+use Spatie\QueueableAction\Tests\TestClasses\ActionWithFailedMethod;
 use Spatie\QueueableAction\Tests\TestClasses\ComplexAction;
 use Spatie\QueueableAction\Tests\TestClasses\DataObject;
 use Spatie\QueueableAction\Tests\TestClasses\SimpleAction;
@@ -123,6 +125,20 @@ class QueueableActionTest extends TestCase
 
         Queue::assertPushed(ActionJob::class, function ($action) {
             return $action->tags() === ['custom_tag', 'tagged_action'];
+        });
+    }
+
+    /** @test */
+    public function an_action_can_have_a_custom_failed_callback()
+    {
+        Queue::fake();
+
+        $action = new ActionWithFailedMethod();
+
+        $action->onQueue()->execute();
+
+        Queue::assertPushed(ActionJob::class, function ($action) {
+            return $action->failed(new Exception('foo')) === 'foo';
         });
     }
 }

--- a/tests/TestClasses/ActionWithFailedMethod.php
+++ b/tests/TestClasses/ActionWithFailedMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Exception;
+use Spatie\QueueableAction\QueueableAction;
+
+class ActionWithFailedMethod
+{
+    use QueueableAction;
+
+    public function execute()
+    {
+        //
+    }
+
+    public function failed(Exception $exception)
+    {
+        return $exception->getMessage();
+    }
+}

--- a/tests/TestClasses/FailingAction.php
+++ b/tests/TestClasses/FailingAction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Exception;
+use Spatie\QueueableAction\QueueableAction;
+
+class FailingAction
+{
+    use QueueableAction;
+
+    public function execute()
+    {
+        throw new Exception('foobar');
+    }
+
+    public function failed(Exception $exception)
+    {
+        $_SERVER['_test_failed_message'] = $exception->getMessage();
+    }
+}


### PR DESCRIPTION
Fixes #28 

Please review.

This can, hypothetically, be a breaking change: If someone had a `failed()` method, it would be executed on failures now. I'm not sure what's your approach with regards to semver, but I personally don't think this is an issue. Seems like an extremely rare case for this to be an issue.