### PR TITLE
Add simple static constructors to the actions

### DIFF
--- a/src/stubs/action-queued.stub
+++ b/src/stubs/action-queued.stub
@@ -19,6 +19,17 @@ class DummyClass
     }
 
     /**
+     * Static class constructor.
+     *
+     * @param  mixed $params
+     * @return static
+     */
+    public static function make(...$params)
+    {
+        return new static(...func_get_args());
+    }
+
+    /**
      * Execute the action.
      *
      * @return mixed

--- a/src/stubs/action.stub
+++ b/src/stubs/action.stub
@@ -15,6 +15,17 @@ class DummyClass
     }
 
     /**
+     * Static class constructor.
+     *
+     * @param  mixed $params
+     * @return static
+     */
+    public static function make(...$params)
+    {
+        return new static(...func_get_args());
+    }
+
+    /**
      * Execute the action.
      *
      * @return mixed


### PR DESCRIPTION
This PR adds an additional method to actions so that they can be constructed statically. For example:

```php
<?php

PublishTweetAction::make($tweet)->onQueue()->execute();
```