### PR TITLE
Add `Batchable` trait to `ActionJob`

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\QueueableAction;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -11,7 +12,7 @@ use Throwable;
 
 class ActionJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable;
+    use Dispatchable, InteractsWithQueue, Queueable, Batchable;
 
     use SerializesModels {
         __sleep as serializesModelsSleep;


### PR DESCRIPTION
I added a `Batchable` trait to the `ActionJob` in order batch actions.
It's not IDE-friendly, the IDE won't show you which parameters the action needs, and it's not a structured solution for batchable actions.

It's kinda a first step of the solution, I created an issue and I would be happy if you guys could comment there and discuss the ideal design. https://github.com/spatie/laravel-queueable-action/issues/40

Thanks!