### PR TITLE
Update Failed method to accept Throwable

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\QueueableAction;
 
-use Exception;
+use Throwable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -59,7 +59,7 @@ class ActionJob implements ShouldQueue
         return $this->middleware;
     }
 
-    public function failed(Exception $exception)
+    public function failed(Throwable $exception)
     {
         if ($this->onFailCallback) {
             return ($this->onFailCallback)($exception);


### PR DESCRIPTION
Changed the Failed method's `$exception` type declaration from `Exception` to `Throwable`.

All tests pass.