### PR TITLE
Add new QueueFake methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The following assertions are available:
 QueueableActionFake::assertPushed(string $actionClass);
 QueueableActionFake::assertPushedTimes(string $actionClass, int $times = 1);
 QueueableActionFake::assertNotPushed(string $actionClass);
+QueueableActionFake::assertPushedWithChain(string $actionClass, array $expextedActionChain = [])
+QueueableActionFake::assertPushedWithoutChain(string $actionClass)
 ```
 
 Feel free to send a PR if you feel any of the other `QueueFake` assertions are missing.

--- a/tests/Testing/QueueableActionTest.php
+++ b/tests/Testing/QueueableActionTest.php
@@ -5,6 +5,7 @@ namespace Spatie\QueueableAction\Tests\Testing;
 use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\ExpectationFailedException;
+use Spatie\QueueableAction\ActionJob;
 use Spatie\QueueableAction\Testing\QueueableActionFake;
 use Spatie\QueueableAction\Tests\TestCase;
 use Spatie\QueueableAction\Tests\TestClasses\SimpleAction;
@@ -56,5 +57,34 @@ class QueueableActionTest extends TestCase
         }
 
         Assert::fail('QueueableAction did not complain about missing `Queue::fake()`.');
+    }
+
+    /** @test */
+    public function it_can_assert_an_action_with_chain_was_pushed()
+    {
+        Queue::fake();
+
+        $action = new SimpleAction();
+
+        $action->onQueue()
+            ->execute()
+            ->chain([
+                new ActionJob(SimpleAction::class),
+                new ActionJob(SimpleAction::class),
+            ]);
+
+        QueueableActionFake::assertPushedWithChain(SimpleAction::class, [SimpleAction::class, SimpleAction::class]);
+    }
+
+    /** @test */
+    public function it_can_assert_an_action_without_chain_was_pushed()
+    {
+        Queue::fake();
+
+        $action = new SimpleAction();
+
+        $action->onQueue()->execute();
+
+        QueueableActionFake::assertPushedWithoutChain(SimpleAction::class);
     }
 }


### PR DESCRIPTION
**Added**
- `assertPushedWithChain(string $actionClass, array $expextedActionChain = [])`
- `assertPushedWithoutChain(string $actionClass)`

Previously if you want to check for chained actions you would have to use Laravel's `assertPushed()` and do the matching with unserializing the `chain` yourself. Now you can assert the chains with:

```
Queue::fake();

(new SimpleAction)
  ->onQueue()
  ->execute()
  ->chain([
                new ActionJob(ChainedAction::class),
                new ActionJob(AnotherChainedAction::class),
            ]);

QueueableActionFake::assertPushedWithChain(SimpleAction::class, [ChainedAction::class, AnotherChainedAction::class]);
```