### PR TITLE
Support for backoff method/property

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,60 @@ class CustomTagsAction
 }
 ```
 
+### Action Backoff
+
+If you would like to configure how many seconds Laravel should wait before retrying an action that has encountered
+an exception on a per-action basis, you may do so by defining a backoff property on your action class:
+
+``` php
+class BackoffAction
+{
+    use QueueableAction;
+    
+    /**
+     * The number of seconds to wait before retrying the action.
+     *
+     * @var array<int>|int
+     */
+    public $backoff = 3;
+}
+```
+
+If you require more complex logic for determining the action's backoff time, you may define a backoff method on your action class:
+
+``` php
+class BackoffAction
+{
+    use QueueableAction;
+    
+    /**
+     * Calculate the number of seconds to wait before retrying the action.
+     *
+     */
+    public function backoff(): int
+    {
+        return 3;
+    }
+}
+```
+
+You may easily configure "exponential" backoffs by returning an array of backoff values from the backoff method.
+In this example, the retry delay will be 1 second for the first retry, 5 seconds for the second retry, and 10 seconds for the third retry:
+
+``` php
+class BackoffAction
+{
+    /**
+     * Calculate the number of seconds to wait before retrying the action.
+     *
+     */
+    public function backoff(): array
+    {
+        return [1, 5, 10];
+    }
+}
+```
+
 ### What is the difference between actions and jobs?
 
 In short: constructor injection allows for much more flexibility.

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -32,6 +32,8 @@ class ActionJob implements ShouldQueue
     /** @var callable */
     protected $onFailCallback;
 
+    protected $backoff;
+
     public function __construct($action, array $parameters = [])
     {
         $this->actionClass = is_string($action) ? $action : get_class($action);
@@ -42,6 +44,9 @@ class ActionJob implements ShouldQueue
             $this->middleware = $action->middleware();
 
             $this->middleware = $action->middleware();
+            if (method_exists($action, 'backoff')) {
+                $this->backoff = $action->backoff();
+            }
 
             if (method_exists($action, 'failed')) {
                 $this->onFailCallback = [$action, 'failed'];
@@ -69,6 +74,11 @@ class ActionJob implements ShouldQueue
     public function parameters()
     {
         return $this->parameters;
+    }
+
+    public function backoff()
+    {
+        return $this->backoff;
     }
 
     public function failed(Throwable $exception)

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -43,7 +43,6 @@ class ActionJob implements ShouldQueue
             $this->tags = $action->tags();
             $this->middleware = $action->middleware();
 
-            $this->middleware = $action->middleware();
             if (method_exists($action, 'backoff')) {
                 $this->backoff = $action->backoff();
             }

--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -77,4 +77,12 @@ trait QueueableAction
 
         return 'execute';
     }
+
+    /**
+     * @return array|int
+     */
+    public function backoff()
+    {
+        return $this->backoff ?? [];
+    }
 }

--- a/tests/TestClasses/BackoffAction.php
+++ b/tests/TestClasses/BackoffAction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Exception;
+use Spatie\QueueableAction\QueueableAction;
+
+class BackoffAction
+{
+    use QueueableAction;
+
+    public function execute()
+    {
+        throw new Exception("Failure with backoff strategy set to 5, 10, 15");
+    }
+
+    public function backoff(): array
+    {
+        return [5, 10, 15];
+    }
+}

--- a/tests/TestClasses/BackoffPropertyAction.php
+++ b/tests/TestClasses/BackoffPropertyAction.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Exception;
+use Spatie\QueueableAction\QueueableAction;
+
+class BackoffPropertyAction
+{
+    use QueueableAction;
+
+    /** @var int */
+    public $backoff = 5;
+
+    public function execute()
+    {
+        throw new Exception("Failure with backoff property set to 5");
+    }
+}


### PR DESCRIPTION
This pull request adds support for the [backoff method/property](https://laravel.com/docs/8.x/upgrade#queue-retry-after-method) introduced in Laravel 8.x.