### PR TITLE
fix testing when custom action job is used

### DIFF
--- a/src/Testing/QueueableActionFake.php
+++ b/src/Testing/QueueableActionFake.php
@@ -73,7 +73,7 @@ class QueueableActionFake
 
     protected static function getPushedCount(string $actionJobClass): int
     {
-        return collect(Queue::pushedJobs()[ActionJob::class] ?? [])
+        return collect(Queue::pushedJobs()[config('queuableaction.job_class') ?? ActionJob::class] ?? [])
             ->map(function (array $queuedJob) {
                 return $queuedJob['job']->displayName();
             })

--- a/tests/Testing/QueueableActionTest.php
+++ b/tests/Testing/QueueableActionTest.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\QueueableAction\Tests\Testing;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\ExpectationFailedException;
 use Spatie\QueueableAction\ActionJob;
 use Spatie\QueueableAction\Testing\QueueableActionFake;
 use Spatie\QueueableAction\Tests\TestCase;
+use Spatie\QueueableAction\Tests\TestClasses\CustomActionJob;
 use Spatie\QueueableAction\Tests\TestClasses\SimpleAction;
 
 class QueueableActionTest extends TestCase
@@ -23,11 +25,41 @@ class QueueableActionTest extends TestCase
 
         QueueableActionFake::assertPushed(SimpleAction::class);
     }
+    
+    /** @test */
+    public function it_can_assert_an_action_was_pushed_with_a_custom_action_job()
+    {
+        Queue::fake();
 
+        Config::set('queuableaction.job_class', CustomActionJob::class);
+
+        $action = new SimpleAction();
+
+        $action->onQueue()->execute();
+
+        QueueableActionFake::assertPushed(SimpleAction::class);
+    }
+
+    
     /** @test */
     public function it_can_assert_an_action_was_pushed_times()
     {
         Queue::fake();
+        
+        $action = new SimpleAction();
+        
+        $action->onQueue()->execute();
+        $action->onQueue()->execute();
+        
+        QueueableActionFake::assertPushedTimes(SimpleAction::class, 2);
+    }
+    
+    /** @test */
+    public function it_can_assert_an_action_was_pushed_times_with_a_custom_action_job()
+    {
+        Queue::fake();
+
+        Config::set('queuableaction.job_class', CustomActionJob::class);
 
         $action = new SimpleAction();
 


### PR DESCRIPTION
When a custom action job was used before the testing methods like `QueueableActionFake::assertPushed()` would not work anymore, because the `ActionJob::class` was used to determine whether the queue includes actions. With this change the `queuableaction.job_class` config is recognized and the test methods work again.

I've added two tests to provide cases which would be failing before.