### PR TITLE
Actions wont fail serialization with a closure and a failed method

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -30,8 +30,8 @@ class ActionJob implements ShouldQueue
     /** @var array */
     protected $tags = ['action_job'];
 
-    /** @var callable */
-    protected $onFailCallback;
+    /** @var string */
+    protected $onFailMethod;
 
     protected $backoff;
 
@@ -49,7 +49,7 @@ class ActionJob implements ShouldQueue
             }
 
             if (method_exists($action, 'failed')) {
-                $this->onFailCallback = [$action, 'failed'];
+                $this->onFailMethod = 'failed';
             }
         }
 
@@ -83,8 +83,9 @@ class ActionJob implements ShouldQueue
 
     public function failed(Throwable $exception)
     {
-        if ($this->onFailCallback) {
-            return ($this->onFailCallback)($exception);
+        if ($this->onFailMethod) {
+            $action = app($this->actionClass);
+            return $action->{$this->onFailMethod}($exception);
         }
     }
 

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -15,6 +15,7 @@ use Spatie\QueueableAction\Tests\TestClasses\ActionWithFailedMethod;
 use Spatie\QueueableAction\Tests\TestClasses\BackoffAction;
 use Spatie\QueueableAction\Tests\TestClasses\BackoffPropertyAction;
 use Spatie\QueueableAction\Tests\TestClasses\ComplexAction;
+use Spatie\QueueableAction\Tests\TestClasses\ClosureActionWithFailedMethod;
 use Spatie\QueueableAction\Tests\TestClasses\ContinueMiddleware;
 use Spatie\QueueableAction\Tests\TestClasses\CustomActionJob;
 use Spatie\QueueableAction\Tests\TestClasses\DataObject;
@@ -274,6 +275,24 @@ class QueueableActionTest extends TestCase
         $this->assertSame($user->id, $unSerializedModel->id);
         $this->assertSame('verified', $unSerializedModel->status);
     }
+
+    /** @test */
+    public function an_action_with_a_closure_and_a_failed_method_serializes()
+    {
+        /** @var \Spatie\QueueableAction\Tests\TestClasses\ClosureActionWithFailedMethod $action */
+        $action = app(ClosureActionWithFailedMethod::class);
+
+        $actionJob = new ActionJob($action);
+
+        // simulate action job is push to the queue
+        $serialized = serialize($actionJob);
+
+        // simulate action job is handled by a queue worker
+        $unSerialized = unserialize($serialized);
+
+        $this->assertInstanceOf(ActionJob::class, $actionJob);
+    }
+
 
     /** @test */
     public function an_action_can_have_a_backoff_property(): void

--- a/tests/TestClasses/ClosureActionWithFailedMethod.php
+++ b/tests/TestClasses/ClosureActionWithFailedMethod.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Exception;
+use Spatie\QueueableAction\QueueableAction;
+
+class ClosureActionWithFailedMethod
+{
+    use QueueableAction;
+
+    /** @var string */
+    public $queue = 'default';
+
+    /** @var string */
+    protected $foo;
+
+    public function __construct()
+    {
+        $this->foo = function() {
+            return 'bar';
+        };
+    }
+
+    public function execute()
+    {
+        return $this->foo;
+    }
+
+    public function failed(Exception $exception)
+    {
+        return $exception->getMessage();
+    }
+}


### PR DESCRIPTION
Thanks for a great package!


## Problem that is fixed by this PR
At the moment if you try to push an Action with a closure or a dependency that has a closure and also have a failed method defined it will throw an exception and fail to be pushed to the queue.


Line 51 on ActionJob.php adds the action to the onFailCallback.
If the action constructor contains a closure  it will fail to serialize.
```php
if (method_exists($action, 'failed')) {
    $this->onFailCallback = [$action, 'failed'];
}
```

This can be tested with:
```php
$actionJob = new ActionJob($action);

// simulate action job is push to the queue
$serialized = serialize($actionJob);

```
and any action that has a closure, for example(see ClosureActionWithFailedMethod.php added in this PR):
```php
public function __construct()
{
    $this->foo = function() {
        return 'bar';
    };
}
```

## Proposed Fix
Only saving the method instead of the callback:
```php
if (method_exists($action, 'failed')) {
    $this->onFailMethod = 'failed';
}
```
And resolving the action in the failed method the same way it is done in the handle method.
```php
if ($this->onFailMethod) {
    $action = app($this->actionClass);
    return $action->{$this->onFailMethod}($exception);
}
```

Another option if you want to keep the `onFailCallback` property as is, but sending in the action class name instead of the object. And resolving it in the failed method.

Happy to change it, if so!

Thanks!

p.s
This was an issue for us as we had an action that depended on a Guzzle Client.
