### PR TITLE
add maxExceptions to properties

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -143,6 +143,7 @@ class ActionJob implements ShouldQueue
             'chained',
             'tries',
             'timeout',
+            'maxExceptions',
         ];
 
         foreach ($queueableProperties as $queueableProperty) {


### PR DESCRIPTION
Allow $maxExceptions property to be added to actions.

https://laravel.com/docs/9.x/queues#max-exceptions