### PR TITLE
Fixes QueueableActionFake to accommodate a custom action job class

### DIFF
--- a/src/Testing/QueueableActionFake.php
+++ b/src/Testing/QueueableActionFake.php
@@ -73,7 +73,7 @@ class QueueableActionFake
 
     protected static function getPushedCount(string $actionJobClass): int
     {
-        return collect(Queue::pushedJobs()[ActionJob::class] ?? [])
+        return collect(Queue::pushedJobs()[self::determineActionJobClass()] ?? [])
             ->map(function (array $queuedJob) {
                 return $queuedJob['job']->displayName();
             })
@@ -90,7 +90,7 @@ class QueueableActionFake
 
     protected static function getChainedClasses()
     {
-        return collect(Queue::pushedJobs()[ActionJob::class] ?? [])
+        return collect(Queue::pushedJobs()[self::determineActionJobClass()] ?? [])
             ->map(fn ($actionJob) => $actionJob['job']->chained)
             ->map(function ($chain) {
                 return collect($chain)->map(function ($job) {
@@ -98,5 +98,10 @@ class QueueableActionFake
                 });
             })
             ->flatten();
+    }
+
+    protected static function determineActionJobClass(): string
+    {
+        return config('queuableaction.job_class') ?? ActionJob::class;
     }
 }

--- a/tests/TestClasses/QueueableActionFakeTestClass.php
+++ b/tests/TestClasses/QueueableActionFakeTestClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Spatie\QueueableAction\Testing\QueueableActionFake;
+
+class QueueableActionFakeTestClass extends QueueableActionFake
+{
+    public static function getPushedCountTest(string $actionJobClass): int
+    {
+        return self::getPushedCount($actionJobClass);
+    }
+
+    public static function getChainedClassesTest()
+    {
+        return self::getChainedClasses();
+    }
+}

--- a/tests/Testing/QueueableActionTest.php
+++ b/tests/Testing/QueueableActionTest.php
@@ -2,12 +2,15 @@
 
 namespace Spatie\QueueableAction\Tests\Testing;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\ExpectationFailedException;
 use Spatie\QueueableAction\ActionJob;
 use Spatie\QueueableAction\Testing\QueueableActionFake;
 use Spatie\QueueableAction\Tests\TestCase;
+use Spatie\QueueableAction\Tests\TestClasses\CustomActionJob;
+use Spatie\QueueableAction\Tests\TestClasses\QueueableActionFakeTestClass;
 use Spatie\QueueableAction\Tests\TestClasses\SimpleAction;
 
 class QueueableActionTest extends TestCase
@@ -86,5 +89,35 @@ class QueueableActionTest extends TestCase
         $action->onQueue()->execute();
 
         QueueableActionFake::assertPushedWithoutChain(SimpleAction::class);
+    }
+
+    /** @test */
+    public function get_pushed_count_can_use_custom_action_job_class()
+    {
+        Config::set('queuableaction.job_class', CustomActionJob::class);
+        Queue::fake();
+
+        $action = new SimpleAction();
+        $action->onQueue()->execute();
+
+        $this->assertEquals(1, QueueableActionFakeTestClass::getPushedCountTest(SimpleAction::class));
+    }
+
+    /** @test */
+    public function get_chained_classes_can_use_custom_action_job_class()
+    {
+        Config::set('queuableaction.job_class', CustomActionJob::class);
+        Queue::fake();
+
+        $action = new SimpleAction();
+
+        $action->onQueue()
+            ->execute()
+            ->chain([
+                new CustomActionJob(SimpleAction::class),
+                new CustomActionJob(SimpleAction::class),
+            ]);
+
+        $this->assertCount(2, QueueableActionFakeTestClass::getChainedClassesTest());
     }
 }


### PR DESCRIPTION
The ability to use a custom `ActionJob` class was introduced in https://github.com/spatie/laravel-queueable-action/pull/46. It, however, did not update the QueueableActionFake class to also allow for it. This PR is to fix that.

I went with a possibly non-standard approach with the tests in that I created a test class to expose the protected methods on `QueueableActionFake`. I went this route so I could just add two additional tests to `QueueableActionTest` instead of duplicating most of the existing tests. I'd be glad to do that if you prefer.