### PR TITLE
Default Action Tags

### DIFF
--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -85,4 +85,12 @@ trait QueueableAction
     {
         return $this->backoff ?? [];
     }
+
+    /**
+     * @return string[]
+     */
+    public function tags(): array
+    {
+        return [self::class];
+    }
 }


### PR DESCRIPTION
Hello,

Queueable actions may [define tags](https://github.com/spatie/laravel-queueable-action#custom-tags) as a handy way to organize actions on Horizon.

This PR adds the action class name as a default tag.