### PR TITLE
Remove duplicated tags function

### DIFF
--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -59,11 +59,6 @@ trait QueueableAction
         return $class;
     }
 
-    public function tags(): array
-    {
-        return ['action_job'];
-    }
-
     public function middleware(): array
     {
         return [];


### PR DESCRIPTION
Sorry, since I did the changes directly on GitHub UI I did not see that `tags` was already declared.

This fixes the issue introduced on v2.14.4