### PR TITLE
Access model properties in ActionJob

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -148,7 +148,7 @@ class ActionJob implements ShouldQueue
 
         foreach ($queueableProperties as $queueableProperty) {
             if (property_exists($action, $queueableProperty)) {
-                $this->{$queueableProperty} = $action->{$queueableProperty};
+                $this->{$queueableProperty} = app($action)->{$queueableProperty};
             }
         }
     }


### PR DESCRIPTION
This resolves the issue identified in https://github.com/spatie/laravel-queueable-action/issues/76

In our QueueableAction class we could have:

`public int $timeout = 240`

Currently when using ActionJob we get:

`PHP Warning:  Attempt to read property "timeout" on string in /Users/me/dev/example-laravel/vendor/spatie/laravel-queueable-action/src/ActionJob.php on line 151
`

This PR fix will now return _240_ whereas it previously returned the warning.

The $action variable is a string of the action ClassName, so we cannot access the $queueableProperty unless we first new up the class. Using the app() helper for this.

