### PR TITLE
Pass the Actions ClassName when Action called directly

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -53,7 +53,7 @@ class ActionJob implements ShouldQueue
             }
         }
 
-        $this->resolveQueueableProperties($action);
+        $this->resolveQueueableProperties($this->actionClass);
     }
 
     public function displayName(): string


### PR DESCRIPTION
My apologies for missing this in https://github.com/spatie/laravel-queueable-action/pull/81

The previous PR will fix for ActionJob but break for QueuableActions called directly as they are passing the $action object as a parameter and not the class name. 

There is already a check in the constructor to determine if class name or class object is passed - so we can use that to resolve this:

https://github.com/spatie/laravel-queueable-action/blob/01da21e5044dd245669cd75922e211264bfee063/src/ActionJob.php#L40

