### PR TITLE
Remove __sleep & __wakeup from ActionJob

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -15,8 +15,6 @@ class ActionJob implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, Batchable;
 
     use SerializesModels {
-        __sleep as serializesModelsSleep;
-        __wakeup as serializesModelsWakeup;
         __serialize as serializesModelsSerialize;
         __unserialize as serializesModelsUnserialize;
     }
@@ -92,24 +90,6 @@ class ActionJob implements ShouldQueue
     {
         $action = app($this->actionClass);
         $action->{$action->queueMethod()}(...$this->parameters);
-    }
-
-    public function __sleep()
-    {
-        foreach ($this->parameters as $index => $parameter) {
-            $this->parameters[$index] = $this->getSerializedPropertyValue($parameter);
-        }
-
-        return $this->serializesModelsSleep();
-    }
-
-    public function __wakeup()
-    {
-        $this->serializesModelsWakeup();
-
-        foreach ($this->parameters as $index => $parameter) {
-            $this->parameters[$index] = $this->getRestoredPropertyValue($parameter);
-        }
     }
 
     public function __serialize()

--- a/tests/ActionMakeCommandTest.php
+++ b/tests/ActionMakeCommandTest.php
@@ -14,7 +14,7 @@ class ActionMakeCommandTest extends TestCase
 
         $this->artisan('make:action', [
             'name' => 'TestAction',
-        ])->expectsOutput('Action created successfully.')->assertExitCode(0);
+        ])->expectsOutputToContain('Action [app/Actions/TestAction.php] created successfully.')->assertExitCode(0);
     }
 
     /** @test */
@@ -25,7 +25,7 @@ class ActionMakeCommandTest extends TestCase
         $this->artisan('make:action', [
             'name' => 'TestAction',
             '--sync' => true,
-        ])->expectsOutput('Action created successfully.')->assertExitCode(0);
+        ])->expectsOutputToContain('Action [app/Actions/TestAction.php] created successfully.')->assertExitCode(0);
     }
 
     private function expectsGeneratedClass(string $filename, string $contents): void


### PR DESCRIPTION
This [PR](https://github.com/laravel/framework/pull/44847) removed the __sleep and __wakeup methods. As this package also requires PHP 8.0 we can safely delete these methods too. See [reference](https://www.php.net/manual/en/language.oop5.magic.php#object.serialize)

Furthermore I fixed the test as the output slightly changed.