### PR TITLE
Add `onQueueWhen` to conditionally queue an action

### DIFF
--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -59,6 +59,15 @@ trait QueueableAction
         return $class;
     }
 
+    public function onQueueWhen(bool|callable $condition, ?string $queue = null)
+    {
+        if (is_callable($condition)) {
+            $condition = $condition();
+        }
+
+        return $condition ? $this->onQueue($queue) : $this;
+    }
+
     public function middleware(): array
     {
         return [];

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -95,6 +95,52 @@ test('an action is executed immediately if not queued', function () {
     assertLogHas('foo bar');
 });
 
+test('an action can be queued when a condition is met', function () {
+    Queue::fake();
+
+    /** @var \Spatie\QueueableAction\Tests\TestClasses\ComplexAction $action */
+    $action = app(ComplexAction::class);
+
+    $action->onQueueWhen(true)->execute(new DataObject('foo'));
+
+    Queue::assertPushed(ActionJob::class);
+});
+
+test('an action can be executed when a condition is not met', function() {
+    Queue::fake();
+
+    /** @var \Spatie\QueueableAction\Tests\TestClasses\ComplexAction $action */
+    $action = app(ComplexAction::class);
+
+    $action->onQueueWhen(false)->execute(new DataObject('bar'));
+
+    Queue::assertNotPushed(ActionJob::class);
+
+    assertLogHas('bar bar');
+});
+
+test('an action can be queued on a specific queue when a condition is met', function () {
+    Queue::fake();
+
+    /** @var \Spatie\QueueableAction\Tests\TestClasses\ComplexAction $action */
+    $action = app(ComplexAction::class);
+
+    $action->onQueueWhen(true, 'other')->execute(new DataObject('foo'));
+
+    Queue::assertPushedOn('other', ActionJob::class);
+});
+
+test('an action can be queued when a callable condition is met', function () {
+    Queue::fake();
+
+    /** @var \Spatie\QueueableAction\Tests\TestClasses\ComplexAction $action */
+    $action = app(ComplexAction::class);
+
+    $action->onQueueWhen(fn () => true)->execute(new DataObject('foo'));
+
+    Queue::assertPushed(ActionJob::class);
+});
+
 test('an action can be queued with a chain of other actions jobs', function () {
     Queue::fake();
 


### PR DESCRIPTION
A lot of the time when I'm dealing with Queueable Actions I only want to queue them based on a condition. ie, if the number of rows to be updated is below 10 perform the action in the current request, otherwise queue it.

This can be handled by:

```php
// before
if ($count < 10) {
    $this->updateRowsAction->execute(
        request()->user(),
        $variableA,
        $variableB,
        $variableC,
    );
    
    return;
}

$this->updateRowsAction->onQueue()->execute(        
    request()->user(),
    $variableA,
    $variableB,
    $variableC,
);

// after
$this->updateRowsAction->onQueueWhen($count >= 10)->execute(        
    request()->user(),
    $variableA,
    $variableB,
    $variableC,
);
```

