### PR TITLE
feat: Add capacity for unique queueable jobs

### DIFF
--- a/config/queuableaction.php
+++ b/config/queuableaction.php
@@ -7,4 +7,11 @@ return [
      * it must extend the \Spatie\QueueableAction\ActionJob class.
      */
     'job_class' => \Spatie\QueueableAction\ActionJob::class,
+
+    /*
+     * The job class that will be dispatched for unique jobs.
+     * If you would like to change it and use your own job class,
+     * it must extend the \Spatie\QueueableAction\ActionJob class.
+     */
+    'unique_job_class' => \Spatie\QueueableAction\UniqueActionJob::class,
 ];

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -33,6 +33,8 @@ class ActionJob implements ShouldQueue
 
     protected $backoff;
 
+    protected $uniqueId;
+    
     public function __construct($action, array $parameters = [])
     {
         $this->actionClass = is_string($action) ? $action : get_class($action);
@@ -130,6 +132,7 @@ class ActionJob implements ShouldQueue
             'maxExceptions',
             'retryUntil',
             'uniqueFor',
+            'uniqueVia',
         ];
 
         foreach ($queueableProperties as $queueableProperty) {

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -49,6 +49,10 @@ class ActionJob implements ShouldQueue
             if (method_exists($action, 'failed')) {
                 $this->onFailCallback = [$action, 'failed'];
             }
+
+            if (method_exists($action, 'uniqueId')) {
+                $this->uniqueId = $action->uniqueId(...$parameters);
+            }
         }
 
         $this->resolveQueueableProperties($this->actionClass);
@@ -125,6 +129,7 @@ class ActionJob implements ShouldQueue
             'timeout',
             'maxExceptions',
             'retryUntil',
+            'uniqueFor',
         ];
 
         foreach ($queueableProperties as $queueableProperty) {

--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\QueueableAction;
 
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Spatie\QueueableAction\Exceptions\InvalidConfiguration;
 
 trait QueueableAction
@@ -47,6 +48,10 @@ trait QueueableAction
             protected function determineActionJobClass(): string
             {
                 $actionJobClass = config('queuableaction.job_class') ?? ActionJob::class;
+
+                if (is_a($this->action, ShouldBeUnique::class)) {
+                    $actionJobClass = config('queuableaction.unique_job_class') ?? UniqueActionJob::class;
+                }
 
                 if (! is_a($actionJobClass, ActionJob::class, true)) {
                     throw InvalidConfiguration::jobClassIsNotValid($actionJobClass);

--- a/src/UniqueActionJob.php
+++ b/src/UniqueActionJob.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\QueueableAction;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+
+class UniqueActionJob extends ActionJob implements ShouldBeUnique
+{
+    /**
+     * The unique ID of the job.
+     */
+    public function uniqueId(): string
+    {
+        return (string) ($this->uniqueId ?? '');
+    }
+}

--- a/src/UniqueActionJob.php
+++ b/src/UniqueActionJob.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
 use Throwable;
 
 class UniqueActionJob extends ActionJob implements ShouldBeUnique
@@ -19,5 +20,15 @@ class UniqueActionJob extends ActionJob implements ShouldBeUnique
     public function uniqueId(): string
     {
         return (string) ($this->uniqueId ?? '');
+    }
+
+    /**
+     * Get the cache driver for the unique job lock.
+     *
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    public function uniqueVia()
+    {
+        return Cache::driver($this->uniqueVia ?? config('cache.default'));
     }
 }


### PR DESCRIPTION
This is more of a proof of concept currently, to discover whether this approach is feasible prior to any tidying up required, as well as testing required, and whether this is likely to be something that can be merged.

The theory here is that implementing the `ShouldBeUnique` interface on the action class itself will cause the method to queue the `UniqueActionJob` class, with the `uniqueId` method being passed the parameters from the execute method to allow for their re-use for things like being unique by model ID.