### PR TITLE
receives job property

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -89,6 +89,7 @@ class ActionJob implements ShouldQueue
     public function handle()
     {
         $action = app($this->actionClass);
+        $action->job = $this->job;
         $action->{$action->queueMethod()}(...$this->parameters);
     }
 

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Spatie\QueueableAction\ActionJob;
 use Spatie\QueueableAction\Exceptions\InvalidConfiguration;
-use Spatie\QueueableAction\Tests\TestClasses\ActionReturningAction;
+use Spatie\QueueableAction\Tests\TestClasses\ActionReturningJob;
 use Spatie\QueueableAction\Tests\TestClasses\ActionWithFailedMethod;
 use Spatie\QueueableAction\Tests\TestClasses\BackoffAction;
 use Spatie\QueueableAction\Tests\TestClasses\BackoffPropertyAction;
@@ -51,7 +51,7 @@ test('an action can be queued', function () {
 });
 
 test('an action can be queued and receives job property', function () {
-    $action = new ActionReturningAction();
+    $action = new ActionReturningJob();
     $job = $action->onQueue()->execute();
     assertInstanceOf(\Illuminate\Foundation\Bus\PendingDispatch::class, $job);
 });

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Spatie\QueueableAction\ActionJob;
 use Spatie\QueueableAction\Exceptions\InvalidConfiguration;
+use Spatie\QueueableAction\Tests\TestClasses\ActionReturningAction;
 use Spatie\QueueableAction\Tests\TestClasses\ActionWithFailedMethod;
 use Spatie\QueueableAction\Tests\TestClasses\BackoffAction;
 use Spatie\QueueableAction\Tests\TestClasses\BackoffPropertyAction;
@@ -27,6 +28,8 @@ use Spatie\QueueableAction\Tests\TestClasses\ModelSerializationUser;
 use Spatie\QueueableAction\Tests\TestClasses\SimpleAction;
 use Spatie\QueueableAction\Tests\TestClasses\TaggedAction;
 use stdClass;
+use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertTrue;
 
 beforeEach(function () {
     config()->set('database.default', 'testing');
@@ -45,6 +48,12 @@ test('an action can be queued', function () {
     $action->onQueue()->execute();
 
     Queue::assertPushed(ActionJob::class);
+});
+
+test('an action can be queued and receives job property', function () {
+    $action = new ActionReturningAction();
+    $job = $action->onQueue()->execute();
+    assertInstanceOf(\Illuminate\Foundation\Bus\PendingDispatch::class, $job);
 });
 
 test('an action with dependencies and input can be executed on the queue', function () {

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -53,7 +53,7 @@ test('an action can be queued', function () {
 test('an action can be queued and receives job property', function () {
     $action = new ActionReturningJob();
     $job = $action->onQueue()->execute();
-    assertInstanceOf(\Illuminate\Foundation\Bus\PendingDispatch::class, $job);
+    expect($job)->toBeInstanceOf(\Illuminate\Foundation\Bus\PendingDispatch::class);
 });
 
 test('an action with dependencies and input can be executed on the queue', function () {

--- a/tests/TestClasses/ActionReturningAction.php
+++ b/tests/TestClasses/ActionReturningAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Spatie\QueueableAction\QueueableAction;
+
+/**
+ * @property $job
+ */
+class ActionReturningAction
+{
+    use QueueableAction;
+
+    public function execute()
+    {
+        return $this->job;
+    }
+}

--- a/tests/TestClasses/ActionReturningJob.php
+++ b/tests/TestClasses/ActionReturningJob.php
@@ -7,7 +7,7 @@ use Spatie\QueueableAction\QueueableAction;
 /**
  * @property $job
  */
-class ActionReturningAction
+class ActionReturningJob
 {
     use QueueableAction;
 


### PR DESCRIPTION
Hi,
I am submitting this pull request to enhance the job handling capabilities by explicitly passing the $job property into the job's action method. This addition allows developers to have more control over the job execution process, such as managing retries, deletions, and failures more effectively.
Moreover, this change improves compatibility with job monitoring packages, such as [Laravel-Queue-Monitor](https://github.com/romanzipp/Laravel-Queue-Monitor)