### PR TITLE
Fix: Add `$job` property to `QueueableAction` to address deprecated dynamic properties in PHP >= 8.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.1, 8.0]
+        php: [8.4, 8.3, 8.2, 8.1, 8.0]
         laravel: ['9.*', '10.*', '11.*']
         dependency-version: [prefer-stable]
         include:

--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -2,10 +2,13 @@
 
 namespace Spatie\QueueableAction;
 
+use Illuminate\Contracts\Queue\Job;
 use Spatie\QueueableAction\Exceptions\InvalidConfiguration;
 
 trait QueueableAction
 {
+    public ?Job $job;
+
     /**
      * @return static
      */


### PR DESCRIPTION
This pull request introduces updates to the GitHub Actions workflow and the QueueableAction trait to ensure compatibility with PHP versions 8.3 and higher, **addressing the issue of deprecated dynamic properties**.


- Introduced a nullable `$job` property to the `QueueableAction` trait, preventing dynamic property warnings in PHP 8.2+.
- Added PHP 8.3 and 8.4 to the testing matrix, ensuring the package’s compatibility with the latest PHP versions.

#110 