### PR TITLE
Support WithoutRelations for queueable action class & parameters to emulate Laravel's WithoutRelations attribute

### DIFF
--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -75,12 +75,14 @@ class ActionJob implements ShouldQueue
         $reflection = new ReflectionClass($this->actionClass);
         $reflectionParameters = $reflection->getMethod($action->queueMethod())->getParameters();
 
+        $useClassWithoutRelations = !empty($reflection->getAttributes(WithoutRelations::class));
+
         foreach ($reflectionParameters as $key => $reflectionParameter) {
-            if (empty($parameters[$key])) {
+            if (!$useClassWithoutRelations && empty($parameters[$key])) {
                 continue;
             }
 
-            if (empty($reflectionParameter->getAttributes(WithoutRelations::class))) {
+            if (!$useClassWithoutRelations && empty($reflectionParameter->getAttributes(WithoutRelations::class))) {
                 continue;
             }
 

--- a/src/ActionJob.php
+++ b/src/ActionJob.php
@@ -68,21 +68,21 @@ class ActionJob implements ShouldQueue
 
     private function resolveParameters($action, array $parameters): array
     {
-        if (!is_object($action) || !method_exists($action, 'queueMethod')) {
+        if (! is_object($action) || ! method_exists($action, 'queueMethod')) {
             return $parameters;
         }
 
         $reflection = new ReflectionClass($this->actionClass);
         $reflectionParameters = $reflection->getMethod($action->queueMethod())->getParameters();
 
-        $useClassWithoutRelations = !empty($reflection->getAttributes(WithoutRelations::class));
+        $useClassWithoutRelations = ! empty($reflection->getAttributes(WithoutRelations::class));
 
         foreach ($reflectionParameters as $key => $reflectionParameter) {
-            if (!$useClassWithoutRelations && empty($parameters[$key])) {
+            if (! $useClassWithoutRelations && empty($parameters[$key])) {
                 continue;
             }
 
-            if (!$useClassWithoutRelations && empty($reflectionParameter->getAttributes(WithoutRelations::class))) {
+            if (! $useClassWithoutRelations && empty($reflectionParameter->getAttributes(WithoutRelations::class))) {
                 continue;
             }
 
@@ -93,17 +93,20 @@ class ActionJob implements ShouldQueue
                     fn (mixed $parameter) => $this->resolveWithoutRelationsParameter($parameter),
                     $parameter
                 );
+
                 continue;
             }
 
             if ($parameter instanceof Enumerable) {
                 $parameters[$key] = $parameter
                     ->map(fn (mixed $parameter) => $this->resolveWithoutRelationsParameter($parameter));
+
                 continue;
             }
 
             $parameters[$key] = $this->resolveWithoutRelationsParameter($parameter);
         }
+
         return $parameters;
     }
 

--- a/src/Attributes/WithoutRelations.php
+++ b/src/Attributes/WithoutRelations.php
@@ -5,7 +5,6 @@ namespace Spatie\QueueableAction\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PARAMETER)]
-
 class WithoutRelations
 {
 }

--- a/src/Attributes/WithoutRelations.php
+++ b/src/Attributes/WithoutRelations.php
@@ -4,7 +4,7 @@ namespace Spatie\QueueableAction\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PARAMETER)]
 
 class WithoutRelations
 {

--- a/src/Attributes/WithoutRelations.php
+++ b/src/Attributes/WithoutRelations.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\QueueableAction\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+
+class WithoutRelations
+{
+}

--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -15,7 +15,7 @@ trait QueueableAction
     public function onQueue(?string $queue = null)
     {
         /** @var self $class */
-        $class = new class ($this, $queue) {
+        $class = new class($this, $queue) {
             protected $action;
 
             protected $queue;

--- a/src/QueueableAction.php
+++ b/src/QueueableAction.php
@@ -15,7 +15,7 @@ trait QueueableAction
     public function onQueue(?string $queue = null)
     {
         /** @var self $class */
-        $class = new class($this, $queue) {
+        $class = new class ($this, $queue) {
             protected $action;
 
             protected $queue;

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -22,7 +22,8 @@ use Spatie\QueueableAction\Tests\TestClasses\CountRunsMiddleware;
 use Spatie\QueueableAction\Tests\TestClasses\CustomActionJob;
 use Spatie\QueueableAction\Tests\TestClasses\DataObject;
 use Spatie\QueueableAction\Tests\TestClasses\EloquentModelAction;
-use Spatie\QueueableAction\Tests\TestClasses\EloquentModelWithoutRelationsAction;
+use Spatie\QueueableAction\Tests\TestClasses\EloquentModelWithoutRelationsClassAction;
+use Spatie\QueueableAction\Tests\TestClasses\EloquentModelWithoutRelationsParameterAction;
 use Spatie\QueueableAction\Tests\TestClasses\FailingAction;
 use Spatie\QueueableAction\Tests\TestClasses\InvokeableAction;
 use Spatie\QueueableAction\Tests\TestClasses\MiddlewareAction;
@@ -201,7 +202,7 @@ test('an action can have job middleware', function () {
 test('middleware runs only once', function () {
     $_SERVER['_test_run_count_middleware'] = 0;
 
-    $action = new class () extends SimpleAction {
+    $action = new class extends SimpleAction {
         public function middleware(): array
         {
             return [new CountRunsMiddleware()];
@@ -279,7 +280,8 @@ test('an action serializes and deserializes an eloquent model', function (
 })
     ->with([
         [EloquentModelAction::class, true],
-        [EloquentModelWithoutRelationsAction::class, false],
+        [EloquentModelWithoutRelationsParameterAction::class, false],
+        [EloquentModelWithoutRelationsClassAction::class, false],
     ]);
 
 test('an action can have a backoff property', function () {

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -290,13 +290,12 @@ test('an action serializes eloquent model respecting without relations attribute
 
     $actionJob = new ActionJob($action, [$user]);
 
-    // simulate action job is push to the queue
+    // simulate action job is pushed to the queue
     $serialized = serialize($actionJob);
 
-    // simulate action job is handled by a queue worker
+    // deserialize to assert which properties were loaded
     $unSerialized = unserialize($serialized);
 
-    // the model should be deserialized by pulling the latest instance from the database
     $unSerializedModel = $unSerialized->parameters()[0];
 
     expect($unSerializedModel)->toBeInstanceOf(ModelSerializationUser::class)
@@ -324,19 +323,18 @@ test(
 
         $action = app($actionClass);
 
-        // make sure relation was loaded before passing to action
+        // make sure relations were loaded before passing to action
         $user->load('children');
         $child->load('children');
 
         $actionJob = new ActionJob($action, [collect([$user, $child])]);
 
-        // simulate action job is push to the queue
+        // simulate action job is pushed to the queue
         $serialized = serialize($actionJob);
 
-        // simulate action job is handled by a queue worker
+        // deserialize to assert which properties were loaded
         $unSerialized = unserialize($serialized);
 
-        // the model should be deserialized by pulling the latest instance from the database
         $unSerializedModelCollection = $unSerialized->parameters()[0];
 
         expect($unSerializedModelCollection)->toBeInstanceOf(Collection::class)

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -244,7 +244,7 @@ test('a custom job class must extends action job', function () {
 
 test('an action serializes and deserializes an eloquent model', function (
     string $actionClass,
-    bool   $expectRelationsSerialized
+    bool $expectRelationsSerialized
 ) {
     $user = ModelSerializationUser::create([
         'status' => 'unverified',

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -42,7 +42,7 @@ beforeEach(function () {
     Schema::create('users', function (Blueprint $table) {
         $table->increments('id');
         $table->foreignId('parent_id')->nullable()->constrained('users')->nullOnDelete();
-        $table->string('status');
+        $table->string('status')->nullable();
     });
 });
 
@@ -276,12 +276,8 @@ test('an action serializes eloquent model respecting without relations attribute
     string $actionClass,
     bool $expectRelationsSerialized
 ) {
-    $user = ModelSerializationUser::create([
-        'status' => 'unverified',
-    ]);
-    $user->children()->create([
-        'status' => 'unverified',
-    ]);
+    $user = ModelSerializationUser::create([]);
+    $user->children()->create([]);
 
     $action = app($actionClass);
 
@@ -314,12 +310,8 @@ test(
         string $actionClass,
         bool $expectRelationsSerialized
     ) {
-        $user = ModelSerializationUser::create([
-            'status' => 'unverified',
-        ]);
-        $child = $user->children()->create([
-            'status' => 'unverified',
-        ]);
+        $user = ModelSerializationUser::create([]);
+        $child = $user->children()->create([]);
 
         $action = app($actionClass);
 

--- a/tests/QueueableActionTest.php
+++ b/tests/QueueableActionTest.php
@@ -283,7 +283,6 @@ test('an action serializes eloquent model respecting without relations attribute
         'status' => 'unverified',
     ]);
 
-    /** @var \Spatie\QueueableAction\Tests\TestClasses\EloquentModelAction $action */
     $action = app($actionClass);
 
     // make sure relation was loaded before passing to action
@@ -323,7 +322,6 @@ test(
             'status' => 'unverified',
         ]);
 
-        /** @var \Spatie\QueueableAction\Tests\TestClasses\EloquentModelAction $action */
         $action = app($actionClass);
 
         // make sure relation was loaded before passing to action

--- a/tests/TestClasses/EloquentModelCollectionAction.php
+++ b/tests/TestClasses/EloquentModelCollectionAction.php
@@ -3,14 +3,15 @@
 namespace Spatie\QueueableAction\Tests\TestClasses;
 
 use Illuminate\Database\Eloquent\Model;
-use Spatie\QueueableAction\Attributes\WithoutRelations;
+use Illuminate\Support\Collection;
 use Spatie\QueueableAction\QueueableAction;
 
-class EloquentModelWithoutRelationsParameterAction
+class EloquentModelCollectionAction
 {
     use QueueableAction;
 
-    public function execute(#[WithoutRelations] Model $model)
+    /** @param Collection<Model> $models */
+    public function execute(Collection $models)
     {
     }
 }

--- a/tests/TestClasses/EloquentModelWithoutRelationsAction.php
+++ b/tests/TestClasses/EloquentModelWithoutRelationsAction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\QueueableAction\Attributes\WithoutRelations;
+use Spatie\QueueableAction\QueueableAction;
+
+class EloquentModelWithoutRelationsAction
+{
+    use QueueableAction;
+
+    public function execute(#[WithoutRelations] Model $model)
+    {
+    }
+}

--- a/tests/TestClasses/EloquentModelWithoutRelationsClassAction.php
+++ b/tests/TestClasses/EloquentModelWithoutRelationsClassAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\QueueableAction\Attributes\WithoutRelations;
+use Spatie\QueueableAction\QueueableAction;
+
+#[WithoutRelations]
+class EloquentModelWithoutRelationsClassAction
+{
+    use QueueableAction;
+
+    public function execute(Model $model)
+    {
+    }
+}

--- a/tests/TestClasses/EloquentModelWithoutRelationsCollectionParameterAction.php
+++ b/tests/TestClasses/EloquentModelWithoutRelationsCollectionParameterAction.php
@@ -3,14 +3,16 @@
 namespace Spatie\QueueableAction\Tests\TestClasses;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Spatie\QueueableAction\Attributes\WithoutRelations;
 use Spatie\QueueableAction\QueueableAction;
 
-class EloquentModelWithoutRelationsParameterAction
+class EloquentModelWithoutRelationsCollectionParameterAction
 {
     use QueueableAction;
 
-    public function execute(#[WithoutRelations] Model $model)
+    /** @param Collection<Model> $models */
+    public function execute(#[WithoutRelations] Collection $models)
     {
     }
 }

--- a/tests/TestClasses/EloquentModelWithoutRelationsParameterAction.php
+++ b/tests/TestClasses/EloquentModelWithoutRelationsParameterAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\QueueableAction\Tests\TestClasses;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\QueueableAction\Attributes\WithoutRelations;
+use Spatie\QueueableAction\QueueableAction;
+
+#[WithoutRelations]
+class EloquentModelWithoutRelationsParameterAction
+{
+    use QueueableAction;
+
+    public function execute(Model $model)
+    {
+    }
+}

--- a/tests/TestClasses/ModelSerializationUser.php
+++ b/tests/TestClasses/ModelSerializationUser.php
@@ -3,10 +3,29 @@
 namespace Spatie\QueueableAction\Tests\TestClasses;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class ModelSerializationUser extends Model
 {
     public $table = 'users';
     public $guarded = [];
     public $timestamps = false;
+
+    /**
+     * @return BelongsTo<self, $this>
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class);
+    }
+
+    /**
+     * @return HasMany<self, $this>
+     */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
 }

--- a/tests/TestClasses/ModelSerializationUser.php
+++ b/tests/TestClasses/ModelSerializationUser.php
@@ -3,7 +3,6 @@
 namespace Spatie\QueueableAction\Tests\TestClasses;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class ModelSerializationUser extends Model
@@ -11,15 +10,7 @@ class ModelSerializationUser extends Model
     public $table = 'users';
     public $guarded = [];
     public $timestamps = false;
-
-    /**
-     * @return BelongsTo<self, $this>
-     */
-    public function parent(): BelongsTo
-    {
-        return $this->belongsTo(self::class);
-    }
-
+    
     /**
      * @return HasMany<self, $this>
      */


### PR DESCRIPTION
Within our own projects we missed the ability to leverage [WithoutRelations](https://laravel.com/docs/12.x/queues#handling-relationships) for queueable actions.
 

Laravel's `Illuminate\Queue\Attributes\WithoutRelations` can not be used to offer the same functionality, because it does not support parameters, only classes and properties.

This PR introduces support for `\Spatie\QueueableAction\Attributes\WithoutRelations` which should have the same behavior.

I did not find specific cons, nor requests, for this feature. So I'm not sure how many people need it, but I liked it, so decided to share.


Usage can be on parameter level:


```php
use Spatie\QueueableAction;
use Spatie\QueueableAction\Attributes\WithoutRelations;

class MyInvokeableAction
{
    use QueueableAction;

    public function __invoke(
        #[WithoutRelations] MyModel $model,
        MyModel $otherModel,
        RequestData $requestData
    ) {
        // $model does not contain its relations until loaded explicitly
        // $otherModel is unaffected and may contain loaded relations
        // $requestData is unaffected
    }
}
```

or on class level:


```php
use Spatie\QueueableAction;
use Spatie\QueueableAction\Attributes\WithoutRelations;

#[WithoutRelations] 
class MyInvokeableAction
{
    use QueueableAction;

    public function __invoke(
        MyModel $model,
        MyModel $otherModel,
        RequestData $requestData
    ) {
        // $model does not contain its relations until loaded explicitly
        // $otherModel also does not contain its relations until loaded explicitly
        // $requestData is unaffected
    }
}
```

it will also work for models in arrays or collections.

It _would_ have been possible to _also_ support Laravel's `Illuminate\Queue\Attributes\WithoutRelations` on class level, but since that is not currently a dependency of this project and perhaps it's clearer if we only support one, for consistency.

